### PR TITLE
cli fileinputoutput: start bots with run instead of start

### DIFF
--- a/ansible/tasks/cli/03_fileinputoutput.yml
+++ b/ansible/tasks/cli/03_fileinputoutput.yml
@@ -2,13 +2,10 @@
     path: /assets/foo.txt
     create: true
     line: foobar
-- name: Start file-output bot
-  command: intelmqctl start file-output
-- name: Start file-input bot
-  command: intelmqctl start file-input
-  ignore_errors: yes
-- name: Stop file-output bot
-  command: intelmqctl stop file-output
+- name: Run file-input bot once
+  command: intelmqctl run file-input process
+- name: Run file-output bot once
+  command: intelmqctl run file-output process
 - slurp:
     src: /var/lib/intelmq/bots/file-output/events.txt
   register: events


### PR DESCRIPTION
running the bot directly with `intelmqctl run bot-id process` ensures
that at least one and exactly one message is processed until the process
termination reducing accidental timing errors and alike